### PR TITLE
Fix bad xref-pop-to-location call

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -656,8 +656,8 @@ Show ERROR-MESSAGE if result is empty."
           (if (not (cdr xrefs))
               (progn
                 (xref-push-marker-stack)
-                (xref--pop-to-location (cl-first xrefs)
-                                       (assoc-default 'display-action display-action)))
+                (xref-pop-to-location (cl-first xrefs)
+                                      (assoc-default 'display-action display-action)))
             (xref--show-xrefs (if (functionp 'xref--create-fetcher)
                                   (-const xrefs)
                                 xrefs)

--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -656,8 +656,11 @@ Show ERROR-MESSAGE if result is empty."
           (if (not (cdr xrefs))
               (progn
                 (xref-push-marker-stack)
-                (xref-pop-to-location (cl-first xrefs)
-                                      (assoc-default 'display-action display-action)))
+                (funcall (if (fboundp 'xref-pop-to-location)
+                             'xref-pop-to-location
+                           'xref--pop-to-location)
+                         (cl-first xrefs)
+                         (assoc-default 'display-action display-action)))
             (xref--show-xrefs (if (functionp 'xref--create-fetcher)
                                   (-const xrefs)
                                 xrefs)


### PR DESCRIPTION
Emacs commit [4f479aeb4b13d640df21b4943beb0935f75b5126](https://github.com/emacs-mirror/emacs/commit/4f479aeb4b13d640df21b4943beb0935f75b5126) changed the API and broke
`M-.` .