### PR TITLE
makes virtual_environment in jedi setup code be expanduser'd

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -101,6 +101,7 @@ virtual_environment = sys.argv[-1]
 import os
 
 server_directory = os.path.expanduser(server_directory)
+virtual_environment = os.path.expanduser(virtual_environment)
 
 if not os.path.exists(server_directory):
     os.makedirs(server_directory)


### PR DESCRIPTION
When `python-shell-virtualenv-root` is set to a user directory (say "~/anaconda"),
the line 170 of anaconda-mode.el:
`virtual_environment = jedi.create_environment(virtual_environment, safe=False)`
Errors out as follows:

`Traceback (most recent call last):
  File "<string>", line 84, in <module>
  File "/Users/jgrey/.emacs.d/.cache/anaconda-mode/0.1.13/jedi-0.13.2-py3.5.egg/jedi/api/environment.py", line 304, in create_environment
    return Environment(_get_executable_path(path, safe=safe))

  File "/Users/jgrey/.emacs.d/.cache/anaconda-mode/0.1.13/jedi-0.13.2-py3.5.egg/jedi/api/environment.py", line 317, in _get_executable_path
    raise InvalidPythonEnvironment("%s seems to be missing." % python)
jedi.api.environment.InvalidPythonEnvironment: ~/anaconda/bin/python seems to be missing.`

This pull request fixes that by calling expanduser on the virtual_environment path.
