### PR TITLE
Prevent conflicts with stdlib modules by changing working directory

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -376,12 +376,27 @@ be bound."
                 (equal (process-get anaconda-mode-process 'remote-port)
                        (pythonic-remote-port)))))))
 
+(defun anaconda-mode-get-server-process-cwd ()
+  "Get the working directory for starting the anaconda server process.
+
+The current working directory ends up being on sys.path, which may
+result in conflicts with stdlib modules.
+
+When running python from the local machine, we start the server
+process from `anaconda-mode-installation-directory'.
+This function creates that directory if it doesn't exist yet."
+  (when (pythonic-local-p)
+    (unless (file-directory-p anaconda-mode-installation-directory)
+      (make-directory anaconda-mode-installation-directory t))
+    anaconda-mode-installation-directory))
+
 (defun anaconda-mode-bootstrap (&optional callback)
   "Run `anaconda-mode' server.
 CALLBACK function will be called when `anaconda-mode-port' will
 be bound."
   (setq anaconda-mode-process
         (pythonic-start-process :process anaconda-mode-process-name
+                                :cwd (anaconda-mode-get-server-process-cwd)
                                 :buffer (get-buffer-create anaconda-mode-process-buffer)
                                 :query-on-exit nil
                                 :filter (lambda (process output)


### PR DESCRIPTION
Change the current directory when starting the anaconda server.

The current directory will be added to sys.path and we may end up with
files that conflict with stdlib modules. That may prevent the anaconda
server from starting:

Let's say we're working on a package 'foo', that contains a module
'foo.logging'.

The following commands can be used to create such a package:
```
,----
| mkdir foo
| touch foo/__init__.py
| touch foo/logging.py
| touch foo/core.py
`----
```
If we then open foo/core.py with `emacs foo/core.py`, the
`*anaconda-mode*` buffer contains the following error:

```
,----
| Traceback (most recent call last):
|   File "<string>", line 65, in <module>
|   File "/home/ralf/.emacs.d/anaconda-mode/0.1.13/jedi-0.17.2-py3.8.egg/jedi/__init__.py", line 32, in <module>
|     from jedi.api import Script, Interpreter, set_debug_function, \
|   File "/home/ralf/.emacs.d/anaconda-mode/0.1.13/jedi-0.17.2-py3.8.egg/jedi/api/__init__.py", line 15, in <module>
|     import parso
|   File "/home/ralf/.emacs.d/anaconda-mode/0.1.13/parso-0.7.0-py3.8.egg/parso/__init__.py", line 42, in <module>
|     from parso.grammar import Grammar, load_grammar
|   File "/home/ralf/.emacs.d/anaconda-mode/0.1.13/parso-0.7.0-py3.8.egg/parso/grammar.py", line 7, in <module>
|     from parso.python.diff import DiffParser
|   File "/home/ralf/.emacs.d/anaconda-mode/0.1.13/parso-0.7.0-py3.8.egg/parso/python/diff.py", line 39, in <module>
|     LOG = logging.getLogger(__name__)
| AttributeError: module 'logging' has no attribute 'getLogger'
`----
```

In that case python tried to import the stdlib logging module from
foo/logging.py, which is of course bound to fail.