### PR TITLE
Prioritise server directory dependencies over virtual environment's

### DIFF
--- a/anaconda-mode.py
+++ b/anaconda-mode.py
@@ -34,6 +34,7 @@ service_factory_dep = ('service_factory', '0.1.6')
 if not os.path.exists(server_directory):
     os.makedirs(server_directory)
 site.addsitedir(server_directory)
+sys.path.insert(0, server_directory)
 
 missing_dependencies = []
 


### PR DESCRIPTION
I was using `poetry.el` and `anaconda-mode` together, and anaconda was using the project's `jedi` package instead of the one in the server, as `site.addsitedir()` `.append()`s the folder to the path, instead of prepending it.

This is a rather rudimentary fix as I'm not entirely sure what `site.addsitedir()` does.

Feedback/alternative fix is welcome.