### PR TITLE
Add eldoc compliance

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -709,15 +709,14 @@ Show ERROR-MESSAGE if result is empty."
 
 ;;; Eldoc.
 
-(defun anaconda-mode-eldoc-function ()
+(defun anaconda-mode-eldoc-function (callback &rest _ignored)
   "Show eldoc for context at point."
-  (anaconda-mode-call "eldoc" 'anaconda-mode-eldoc-callback)
+  (anaconda-mode-call
+   "eldoc"
+   (lambda (x)
+     (funcall callback (anaconda-mode-eldoc-format x))))
   ;; Don't show response buffer name as ElDoc message.
   nil)
-
-(defun anaconda-mode-eldoc-callback (result)
-  "Display eldoc from server RESULT."
-  (eldoc-message (anaconda-mode-eldoc-format result)))
 
 (defun anaconda-mode-eldoc-format (result)
   "Format eldoc string from RESULT."

--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -777,13 +777,14 @@ Show ERROR-MESSAGE if result is empty."
 
 (defun turn-on-anaconda-eldoc-mode ()
   "Turn on `anaconda-eldoc-mode'."
-  (make-local-variable 'eldoc-documentation-function)
-  (setq-local eldoc-documentation-function 'anaconda-mode-eldoc-function)
+  (add-hook 'eldoc-documentation-functions
+            'anaconda-mode-eldoc-function nil 't)
   (eldoc-mode +1))
 
 (defun turn-off-anaconda-eldoc-mode ()
   "Turn off `anaconda-eldoc-mode'."
-  (kill-local-variable 'eldoc-documentation-function)
+  (remove-hook 'eldoc-documentation-functions
+               'anaconda-mode-eldoc-function 't)
   (eldoc-mode -1))
 
 (provide 'anaconda-mode)


### PR DESCRIPTION
The goal here is to make `anaconda-eldoc` work with other packages that support `eldoc` such as `flymake`, etc. I have tested the code on Emacs 29. It works with different `eldoc` modes like `compose-eagerly` and `default`.