### PR TITLE
Fix #429: fix eldoc functionality when more than one signature

### DIFF
--- a/anaconda-mode.el
+++ b/anaconda-mode.el
@@ -721,13 +721,16 @@ Show ERROR-MESSAGE if result is empty."
 (defun anaconda-mode-eldoc-format (result)
   "Format eldoc string from RESULT."
   (when result
-    (let ((doc (anaconda-mode-eldoc-format-definition
-                (aref result 0)
-                (aref result 1)
-                (aref result 2))))
+    (let ((doc (seq-map (lambda (s)
+			  (anaconda-mode-eldoc-format-definition
+			   (aref s 0)
+			   (aref s 1)
+			   (aref s 2)))
+			result)))
       (if anaconda-mode-eldoc-as-single-line
-          (substring doc 0 (min (frame-width) (length doc)))
-        doc))))
+	  (let ((d (mapconcat #'identity doc ", ")))
+            (substring d 0 (min (frame-width) (length d))))
+        (mapconcat #'identity doc "\n")))))
 
 (defun anaconda-mode-eldoc-format-definition (name index params)
   "Format function definition from NAME, INDEX and PARAMS."

--- a/anaconda-mode.py
+++ b/anaconda-mode.py
@@ -192,11 +192,11 @@ def get_references(script, line, column):
 @script_method
 def eldoc(script, line, column):
     signatures = script.get_signatures(line, column)
-    if len(signatures) == 1:
-        signature = signatures[0]
-        return [signature.name,
-                signature.index,
-                [param.description[6:] for param in signature.params]]
+    if len(signatures) >= 1:
+        return [(s.name,
+                 s.index,
+                 [param.description[6:] for param in s.params])
+                for s in signatures]
 
 # Run.
 


### PR DESCRIPTION
As reported in #429, the eldoc functionality does not work when jedi returns more than 1 signature. This PR fixes it the issue by combining all signatures, optionally, on a single line (the fix is simple enough).